### PR TITLE
Fix alias path for vitejs in dev & prod env

### DIFF
--- a/vite/config.dev.mjs
+++ b/vite/config.dev.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
     ],
     resolve: {
         alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url))
+            '@': fileURLToPath(new URL('../src', import.meta.url))
         }
     },
     server: {

--- a/vite/config.prod.mjs
+++ b/vite/config.prod.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
     ],
     resolve: {
         alias: {
-          '@': fileURLToPath(new URL('./src', import.meta.url))
+          '@': fileURLToPath(new URL('../src', import.meta.url))
         }
       },
     logLevel: 'warning',


### PR DESCRIPTION
When using imports using the `@` alias it's broken because the config is inside `vite/` folder.

So this pointing to a wrong path (`./src`):
```ts
export default defineConfig({
  resolve: {
    alias: {
      '@': fileURLToPath(new URL('./src', import.meta.url)) // -> `root/vite/src/`
    }
  }
})
```

While it must be pointing to the correct path (`../src`):
```ts
export default defineConfig({
  resolve: {
    alias: {
      '@': fileURLToPath(new URL('../src', import.meta.url)) // -> `root/vite/../src/`
    }
  }
})
```